### PR TITLE
feat: catch resolve errors (fixes #41)

### DIFF
--- a/__tests__/navigations.spec.ts
+++ b/__tests__/navigations.spec.ts
@@ -17,6 +17,14 @@ describe('Navigations', () => {
     expect(wrapper.vm.$router.push).toHaveBeenCalledTimes(1)
   })
 
+  it('can check calls on push even if the route is not declared', async () => {
+    const wrapper = mount(Test)
+
+    wrapper.vm.$router.push({ name: 'hey' })
+    expect(wrapper.vm.$router.push).toHaveBeenCalledWith({ name: 'hey' })
+    expect(wrapper.vm.$router.push).toHaveBeenCalledTimes(1)
+  })
+
   it('can check calls on replace', async () => {
     const wrapper = mount(Test)
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -191,8 +191,13 @@ export function createRouterMock(options: RouterMockOptions = {}): RouterMock {
       return pendingNavigation
     }
 
-    // NOTE: should we trigger a push to reset the internal pending navigation of the router?
-    router.currentRoute.value = router.resolve(to)
+    // we try to resolve the navigation
+    // but catch the error to simplify testing and avoid having to declare
+    // all the routes in the mock router
+    try {
+      // NOTE: should we trigger a push to reset the internal pending navigation of the router?
+      router.currentRoute.value = router.resolve(to)
+    } catch (e) {}
     return Promise.resolve()
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -74,14 +74,25 @@ export interface RouterMockOptions extends Partial<RouterOptions> {
    * START_LOCATION.
    */
   initialLocation?: RouteLocationRaw
+
   /**
    * Run in-component guards. Defaults to false
    */
   runInComponentGuards?: boolean
+
   /**
    * Run per-route guards. Defaults to false
    */
   runPerRouteGuards?: boolean
+
+  /**
+   * By default the mock will allow you to push to locations without adding all
+   * the necessary routes so you can still check if `router.push()` was called
+   * in a specific scenario
+   * (https://github.com/posva/vue-router-mock/issues/41). Set this to `true` to
+   * disable that behavior and throw when `router.push()` fails.
+   */
+  noUndeclaredRoutes?: boolean
 }
 
 /**
@@ -101,7 +112,7 @@ export function createRouterMock(options: RouterMockOptions = {}): RouterMock {
     ...options,
   })
 
-  let { runPerRouteGuards, runInComponentGuards } = options
+  let { runPerRouteGuards, runInComponentGuards, noUndeclaredRoutes } = options
   const initialLocation = options.initialLocation || START_LOCATION
 
   const { push, addRoute, replace } = router
@@ -197,7 +208,11 @@ export function createRouterMock(options: RouterMockOptions = {}): RouterMock {
     try {
       // NOTE: should we trigger a push to reset the internal pending navigation of the router?
       router.currentRoute.value = router.resolve(to)
-    } catch (e) {}
+    } catch (error) {
+      if (noUndeclaredRoutes) {
+        throw error
+      }
+    }
     return Promise.resolve()
   }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Tip: publish the PR and check the checkboxes by simply clicking on them -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Adds a try/catch around the route resolution to simplify testing scenarios where the developers use `router.push({name: 'hey'})` and do not want to declare the corresponding route, as they just want to check if `push` was called.

Fixes #41