### PR TITLE
chore(deps-dev): bump @vue/test-utils from 2.0.0-beta.13 to 2.0.0-rc.0

### DIFF
--- a/__tests__/components.spec.ts
+++ b/__tests__/components.spec.ts
@@ -10,7 +10,7 @@ describe('components', () => {
     )
 
     expect(wrapper.html()).toMatchInlineSnapshot(
-      `"<router-link-stub></router-link-stub>"`
+      `"<router-link-stub to=\\"/\\"></router-link-stub>"`
     )
   })
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@size-limit/preset-small-lib": "^4.7.0",
     "@types/jest": "^26.0.15",
     "@types/jsdom": "^16.2.5",
-    "@vue/test-utils": "^2.0.0-beta.8",
+    "@vue/test-utils": "^2.0.0-rc.0",
     "codecov": "^3.8.1",
     "conventional-changelog-cli": "^2.1.1",
     "jest": "^26.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,10 +878,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.5.tgz#c131d88bd6713cc4d93b3bb1372edb1983225ff0"
   integrity sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw==
 
-"@vue/test-utils@^2.0.0-beta.8":
-  version "2.0.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-beta.13.tgz#482aa29f4e80a713e03e22b736d7465d56909e66"
-  integrity sha512-Au+yGMBPvrtcmPP6W4ielTbNJd3equxVOq1iL0DvpAZJwkGOrdBfFTomMhANODiBVyIEE8HMxhr7YIwDHWO36w==
+"@vue/test-utils@^2.0.0-rc.0":
+  version "2.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.0.tgz#c9bc0f898f386697680fe0991a558876fdd178ad"
+  integrity sha512-sutAkUuE0gxlpzMO4V5SzzEujxdrTDr8YAK2KhhhmLKoNGX59UURXfW+DTLgaygB1n+i6nhs/WD+2A4wtjncSA==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Tip: publish the PR and check the checkboxes by simply clicking on them -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Bumps @vue/test-utils from 2.0.0-beta.13 to 2.0.0-rc.0 and fixes a snapshot (now that VTU renders props on stubs)