### PR TITLE
fix(types): add types export to export mapping in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
+    "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs",
     "import": "./dist/index.mjs"
   },


### PR DESCRIPTION
Without types defined, typescript complains it cannot find the type definition of using NodeNext module resolution. 