### PR TITLE
Update spy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ then you need to manually configure the `spy` option and pass `vi.fn()` to it:
 const router = createRouterMock({
   spy: {
     create: fn => vi.fn(fn),
-    reset: spy => spy.mockReset(),
+    reset: spy => spy.mockClear(),
   },
 })
 ```

--- a/src/router.ts
+++ b/src/router.ts
@@ -134,7 +134,7 @@ export interface RouterMockOptions extends Partial<RouterOptions> {
    * const router = createRouterMock({
    *   spy: {
    *     create: fn => vi.fn(fn),
-   *     reset: spy => spy.mockReset()
+   *     reset: spy => spy.mockClear()
    *   }
    * });
    * ```


### PR DESCRIPTION
The previous documentation suggested using `spy.mockReset()` when adding custom spy functionality with vitest. However this doesn't match the automatic implementation, which uses `spy.mockClear()`.

Using `mockReset` causes issues where the spy doesn't return a promise and can break tests. `mockClear` works as expected.

Making this change to avoid any confusion for future users.